### PR TITLE
Fix unit conversion in w_mean accumulation window length calculation 

### DIFF
--- a/ekf_rio/src/ekf_rio_ros.cpp
+++ b/ekf_rio/src/ekf_rio_ros.cpp
@@ -247,7 +247,7 @@ void EkfRioRos::iterate()
 
     // collect angluar rate measurements during the radar scan
     if (!radar_w_queue_.empty() && (radar_w_queue_.back().time_stamp - radar_w_queue_.front().time_stamp).toSec() <
-                                       config_.radar_frame_ms / 1.0e-3)
+                                       config_.radar_frame_ms / 1.0e3)
       radar_w_queue_.emplace_back(imu_data_);
   }
 

--- a/ekf_yrio/src/ekf_yrio_ros.cpp
+++ b/ekf_yrio/src/ekf_yrio_ros.cpp
@@ -249,7 +249,7 @@ void EkfYRioRos::iterate()
 
     // collect angluar rate measurements during the radar scan
     if (!radar_w_queue_.empty() && (radar_w_queue_.back().time_stamp - radar_w_queue_.front().time_stamp).toSec() <
-                                       config_.radar_frame_ms / 1.0e-3)
+                                       config_.radar_frame_ms / 1.0e3)
       radar_w_queue_.emplace_back(imu_data_);
   }
 

--- a/gnss_x_rio/src/gnss_x_rio_ros.cpp
+++ b/gnss_x_rio/src/gnss_x_rio_ros.cpp
@@ -449,7 +449,7 @@ void GnssXRioRos::iterateImu()
 
     // collect angluar rate measurements during the radar scan
     if (!radar_w_queue_.empty() && (radar_w_queue_.back().time_stamp - radar_w_queue_.front().time_stamp).toSec() <
-                                       config_.radar_frame_ms / 1.0e-3)
+                                       config_.radar_frame_ms / 1.0e3)
       radar_w_queue_.emplace_back(imu_data_);
   }
 }

--- a/x_rio/src/x_rio_ros.cpp
+++ b/x_rio/src/x_rio_ros.cpp
@@ -374,7 +374,7 @@ void XRioRos::iterateImu()
 
     // collect angluar rate measurements during the radar scan
     if (!radar_w_queue_.empty() && (radar_w_queue_.back().time_stamp - radar_w_queue_.front().time_stamp).toSec() <
-                                       config_.radar_frame_ms / 1.0e-3)
+                                       config_.radar_frame_ms / 1.0e3)
       radar_w_queue_.emplace_back(imu_data_);
   }
 }


### PR DESCRIPTION
The integration window value was previously calculated using 18.5 / 0.001, which results in 18,500. However, the integration window is specified in seconds, so the correct conversion should be 18.5 / 1000.0.

While this discrepancy does not significantly affect practical behavior (since radar_w_queue is cleared upon each new trigger) it does introduce a small but systematic error. This fix ensures correctness and consistency in the calculation.